### PR TITLE
Remove packed frontend and backend jars from bundle libs

### DIFF
--- a/bundle/pom.xml
+++ b/bundle/pom.xml
@@ -60,6 +60,16 @@
                 </goals>
                 <configuration>
                     <mainClass>com.example.backend.BackendApplication</mainClass>
+                    <excludes>
+                        <exclude>
+                            <groupId>com.example</groupId>
+                            <artifactId>backend</artifactId>
+                        </exclude>
+                        <exclude>
+                            <groupId>com.example</groupId>
+                            <artifactId>frontend</artifactId>
+                        </exclude>
+                    </excludes>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
I have found that after repacking target bundle, frontend and backend packed jars is present in `BOOT-INF/libs` along with their unpacked classes and resources. That can significaly grow taget jar size. 